### PR TITLE
refactor: AI API에서 인증 미들웨어 제거

### DIFF
--- a/ai/routers/ai_routes.py
+++ b/ai/routers/ai_routes.py
@@ -6,7 +6,6 @@ from services.chromadb_service import ChromaDBService
 from services.huggingface_service import HuggingFaceService
 from templateEngine.prompts.message_analyzer_prompts import TemplateGenerationPromptBuilder, TemplateModificationPromptBuilder
 from templateEngine.integrated_template_pipeline import IntegratedTemplatePipeline, IntegratedGenerationRequest, IntegratedGenerationResult
-from middleware.auth_middleware import get_current_user, get_current_user_id
 
 router = APIRouter(prefix="/ai", tags=["AI Services"])
 
@@ -86,13 +85,9 @@ class IntegratedTemplateResponse(BaseModel):
 
 # OpenAI 라우트 (인증 필요)
 @router.post("/openai/chat", response_model=ChatResponse)
-async def openai_chat(
-    request: ChatRequest,
-    current_user: dict = Depends(get_current_user)
-):
-    """OpenAI 채팅 API (인증 필요)"""
+async def openai_chat(request: ChatRequest):
+    """OpenAI 채팅 API"""
     try:
-        print(f"사용자 {current_user['user_name']}({current_user['email']})가 OpenAI 채팅을 요청했습니다.")
         messages = [{"role": "user", "content": request.message}]
         response = await openai_service.chat_completion(messages, request.model)
         return ChatResponse(response=response, model=request.model)
@@ -195,13 +190,9 @@ async def get_available_models():
 
 # 템플릿 생성 라우트
 @router.post("/template/generate", response_model=TemplateGenerationResponse)
-async def generate_template(
-    request: TemplateGenerationRequest,
-    current_user: dict = Depends(get_current_user)
-):
-    """알림톡 템플릿 생성 (인증 필요)"""
+async def generate_template(request: TemplateGenerationRequest):
+    """알림톡 템플릿 생성"""
     try:
-        print(f"사용자 {current_user['user_name']}({current_user['email']})가 템플릿 생성을 요청했습니다.")
         # 가이드라인 검색을 통한 컨텍스트 생성
         try:
             guidelines = await chromadb_service.search_documents(
@@ -257,13 +248,9 @@ async def generate_template(
 
 # 템플릿 수정 라우트
 @router.post("/template/modify", response_model=TemplateModificationResponse)
-async def modify_template(
-    request: TemplateModificationRequest,
-    current_user: dict = Depends(get_current_user)
-):
-    """채팅을 통한 템플릿 수정 (인증 필요)"""
+async def modify_template(request: TemplateModificationRequest):
+    """채팅을 통한 템플릿 수정"""
     try:
-        print(f"사용자 {current_user['user_name']}({current_user['email']})가 템플릿 수정을 요청했습니다.")
         # 채팅 히스토리를 포함한 프롬프트 구성
         chat_context = ""
         if request.chat_history:
@@ -315,13 +302,9 @@ async def modify_template(
 
 # 통합 템플릿 생성 라우트 (요구사항에 맞는 4단계 흐름)
 @router.post("/template/integrated-generate", response_model=IntegratedTemplateResponse)
-async def integrated_generate_template(
-    request: IntegratedTemplateRequest,
-    current_user: dict = Depends(get_current_user)
-):
-    """통합된 4단계 템플릿 생성 API (인증 필요)"""
+async def integrated_generate_template(request: IntegratedTemplateRequest):
+    """통합된 4단계 템플릿 생성 API"""
     try:
-        print(f"사용자 {current_user['user_name']}({current_user['email']})가 통합 템플릿 생성을 요청했습니다.")
         # 통합 파이프라인 초기화
         await integrated_pipeline.initialize()
         
@@ -351,26 +334,18 @@ async def integrated_generate_template(
 
 # 사용자 권한 API들
 @router.post("/chromadb/documents")
-async def add_documents(
-    request: DocumentRequest,
-    current_user: dict = Depends(get_current_user)
-):
-    """ChromaDB에 문서 추가 (인증된 사용자)"""
+async def add_documents(request: DocumentRequest):
+    """ChromaDB에 문서 추가"""
     try:
-        print(f"사용자 {current_user['user_name']}({current_user['email']})가 문서 추가를 요청했습니다.")
         result = await chromadb_service.add_documents([request.content], [request.metadata])
         return result
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
 @router.delete("/chromadb/documents/{document_id}")
-async def delete_document(
-    document_id: str,
-    current_user: dict = Depends(get_current_user)
-):
-    """ChromaDB에서 문서 삭제 (인증된 사용자)"""
+async def delete_document(document_id: str):
+    """ChromaDB에서 문서 삭제"""
     try:
-        print(f"사용자 {current_user['user_name']}({current_user['email']})가 문서 삭제를 요청했습니다.")
         # 문서 삭제 로직 구현 (ChromaDBService에 메서드 추가 필요)
         return {"message": f"문서 {document_id}가 삭제되었습니다."}
     except Exception as e:


### PR DESCRIPTION
- 인증 미들웨어 import 제거 (get_current_user, get_current_user_id)
- 모든 엔드포인트에서 인증 의존성 제거
- 사용자 정보 로그 출력 제거
- API 설명에서 '(인증 필요)' 텍스트 제거

수정된 엔드포인트:
- /openai/chat - OpenAI 채팅 API
- /template/generate - 알림톡 템플릿 생성
- /template/modify - 템플릿 수정
- /template/integrated-generate - 통합 템플릿 생성
- /chromadb/documents - 문서 추가
- /chromadb/documents/{document_id} - 문서 삭제

백엔드에서 저장 시 로그인한 사용자 정보를 처리할 수 있도록 변경
