### PR TITLE
fix: login 요청 경로 수정

### DIFF
--- a/ai/routers/ai_routes.py
+++ b/ai/routers/ai_routes.py
@@ -10,10 +10,32 @@ from templateEngine.integrated_template_pipeline import IntegratedTemplatePipeli
 router = APIRouter(prefix="/ai", tags=["AI Services"])
 
 # 서비스 인스턴스 초기화
-openai_service = OpenAIService()
-chromadb_service = ChromaDBService()
-huggingface_service = HuggingFaceService()
-integrated_pipeline = IntegratedTemplatePipeline()
+print("AI 서비스 초기화 시작...")
+try:
+    openai_service = OpenAIService()
+    print("✅ OpenAI 서비스 초기화 완료")
+except Exception as e:
+    print(f"❌ OpenAI 서비스 초기화 실패: {e}")
+
+try:
+    chromadb_service = ChromaDBService()
+    print("✅ ChromaDB 서비스 초기화 완료")
+except Exception as e:
+    print(f"❌ ChromaDB 서비스 초기화 실패: {e}")
+
+try:
+    huggingface_service = HuggingFaceService()
+    print("✅ HuggingFace 서비스 초기화 완료")
+except Exception as e:
+    print(f"❌ HuggingFace 서비스 초기화 실패: {e}")
+
+try:
+    integrated_pipeline = IntegratedTemplatePipeline()
+    print("✅ 통합 파이프라인 초기화 완료")
+except Exception as e:
+    print(f"❌ 통합 파이프라인 초기화 실패: {e}")
+
+print("AI 서비스 초기화 완료!")
 
 # Pydantic 모델들
 class ChatRequest(BaseModel):
@@ -193,12 +215,16 @@ async def generate_template(request: TemplateGenerationRequest):
     category = "구매취소"
     """알림톡 템플릿 생성"""
     try:
+        print(f"템플릿 생성 요청 받음: {request.userMessage}")
+        
         # 가이드라인 검색을 통한 컨텍스트 생성
         try:
+            print("ChromaDB 검색 시작...")
             guidelines = await chromadb_service.search_documents(
                 f"{category} {request.userMessage}",
                 3
             )
+            print(f"ChromaDB 검색 완료: {len(guidelines.get('documents', []))}개 문서")
         except Exception as e:
             print(f"가이드라인 검색 실패: {e}")
             guidelines = {"documents": []}
@@ -209,16 +235,20 @@ async def generate_template(request: TemplateGenerationRequest):
             context = "\n".join(guidelines['documents'][:3])
         
         # 프롬프트 빌더 사용
+        print("프롬프트 빌더 초기화 중...")
         prompt_builder = TemplateGenerationPromptBuilder(
             category=category,
-            userMessage=request.userMessage,
+            user_message=request.userMessage,
             context=context
         )
         prompt = prompt_builder.build()
+        print(f"프롬프트 생성 완료 (길이: {len(prompt)}자)")
         
         # OpenAI를 통한 템플릿 생성
+        print("OpenAI API 호출 시작...")
         messages = [{"role": "user", "content": prompt}]
         response = await openai_service.chat_completion(messages, request.model)
+        print(f"OpenAI API 호출 완료 (응답 길이: {len(response)}자)")
         
         # 응답에서 템플릿과 변수 추출 (간단한 파싱)
         template_content = response
@@ -236,6 +266,7 @@ async def generate_template(request: TemplateGenerationRequest):
                 "description": f"{var} 관련 정보"
             })
         
+        print(f"템플릿 생성 완료: {len(variables)}개 변수 추출")
         return TemplateGenerationResponse(
             template_content=template_content,
             variables=variables,
@@ -244,7 +275,11 @@ async def generate_template(request: TemplateGenerationRequest):
         )
         
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        print(f"템플릿 생성 중 에러 발생: {str(e)}")
+        print(f"에러 타입: {type(e).__name__}")
+        import traceback
+        print(f"에러 스택트레이스: {traceback.format_exc()}")
+        raise HTTPException(status_code=500, detail=f"템플릿 생성 실패: {str(e)}")
 
 # 템플릿 수정 라우트
 @router.post("/template/modify", response_model=TemplateModificationResponse)

--- a/front/src/api/index.ts
+++ b/front/src/api/index.ts
@@ -176,4 +176,5 @@ export const aiApiDirect = {
 
 }
 
+export { aiApi }
 export default api

--- a/front/src/api/index.ts
+++ b/front/src/api/index.ts
@@ -3,6 +3,15 @@ import { useUserStore } from '@/stores/user'
 
 // API 기본 설정
 const api = axios.create({
+  baseURL: '/api',
+  timeout: 10000,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+})
+
+// AI 서비스용 API 설정
+const aiApi = axios.create({
   baseURL: '/ai',
   timeout: 10000,
   headers: {
@@ -10,7 +19,7 @@ const api = axios.create({
   },
 })
 
-// 요청 인터셉터
+// 백엔드 API 요청 인터셉터
 api.interceptors.request.use(
   (config) => {
     // user store에서 토큰 가져오기
@@ -25,7 +34,18 @@ api.interceptors.request.use(
   }
 )
 
-// 응답 인터셉터
+// AI 서비스 API 요청 인터셉터 (인증 불필요)
+aiApi.interceptors.request.use(
+  (config) => {
+    // AI 서비스는 인증이 필요하지 않음
+    return config
+  },
+  (error) => {
+    return Promise.reject(error)
+  }
+)
+
+// 백엔드 API 응답 인터셉터
 api.interceptors.response.use(
   (response) => {
     // 카카오 로그인 응답에 대한 디버깅
@@ -40,6 +60,17 @@ api.interceptors.response.use(
       const userStore = useUserStore()
       userStore.logout()
     }
+    return Promise.reject(error)
+  }
+)
+
+// AI 서비스 API 응답 인터셉터 (인증 불필요)
+aiApi.interceptors.response.use(
+  (response) => {
+    return response
+  },
+  async (error) => {
+    // AI 서비스는 인증이 필요하지 않으므로 401 에러 처리 불필요
     return Promise.reject(error)
   }
 )
@@ -103,7 +134,7 @@ export const myPageApi = {
 export const templateApi = {
   // AI를 통한 템플릿 생성
   generateTemplate: (userMessage: string) => 
-    api.post('/ai-generation', { userMessage }),
+    aiApi.post('/template/generate', { userMessage }),
   
   // 템플릿 검증 (백엔드 API를 통해)
   validateTemplate: (templateContent: string, variables: Record<string, any>, category?: string, userMessage?: string) => {
@@ -129,14 +160,6 @@ export const templateApi = {
   
   // 템플릿 수정 요청 (채팅을 통한)
   modifyTemplate: (currentTemplate: string, userMessage: string, chatHistory: any[]) => {
-    const aiApi = axios.create({
-      baseURL: '/ai',
-      timeout: 30000,
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    })
-    
     return aiApi.post('/template/modify', {
       current_template: currentTemplate,
       userMessage: userMessage,
@@ -146,10 +169,10 @@ export const templateApi = {
 }
 
 // AI 서버 직접 호출용 API (템플릿 생성)
-export const aiApi = {
+export const aiApiDirect = {
   // AI 서버에 직접 템플릿 생성 요청
   generateTemplate: (userMessage: string) =>
-    api.post('/template/generate', { userMessage: userMessage })
+    aiApi.post('/template/generate', { userMessage: userMessage })
 
 }
 

--- a/front/src/components/TemplateCreateComponent.vue
+++ b/front/src/components/TemplateCreateComponent.vue
@@ -39,7 +39,7 @@ import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useUserStore } from '@/stores/user'
 import { useTemplateStore } from '@/stores/template'
-import { aiApi } from '@/api'
+import { templateApi } from '@/api'
 
 const router = useRouter()
 const userStore = useUserStore()
@@ -68,7 +68,7 @@ const handleSubmit = async () => {
 
   isGenerating.value = true
   try {
-    const response = await aiApi.generateTemplate(templateStore.userMessage)
+    const response = await templateApi.generateTemplate(templateStore.userMessage)
     templateStore.setUserMessage(templateStore.userMessage)
     // AI 서버의 응답(TemplateGenerationResponse)을 sessionStorage에 저장합니다.
     const responseData = response.data;
@@ -80,7 +80,7 @@ const handleSubmit = async () => {
       templateContent: responseData.template_content,
       variables: variableNames,
       category: responseData.category,
-      userMessage: templateStore.userText
+      userMessage: templateStore.userMessage
     }));
     router.push({
       name: 'template-result',


### PR DESCRIPTION
fix: 프론트엔드 API 경로 설정 오류 수정

---

## ✅ PR 종류
- [x] fix (버그 수정)
- [ ] feat (새로운 기능 추가)
- [ ] refactor (코드 리팩토링)
- [ ] docs (문서 추가 및 수정)
- [ ] style (비즈니스 로직 영향 없는 변경)
- [ ] test (테스트 코드 관련 작업)
- [ ] chore (빌드/설정 등 기타 변경)

---

## �� 작업 내용
- 프론트엔드 API 설정에서 백엔드와 AI 서비스 API 경로 분리
- 로그인 API가 AI 서비스로 잘못 요청되던 문제 해결
- 백엔드 API용(`/api`)과 AI 서비스용(`/ai`) axios 인스턴스 분리
- 각 서비스별 독립적인 인터셉터 설정

---

## 🔍 변경 이유
- 로그인 시 404 오류 발생: `/ai/auth/login` 엔드포인트를 찾을 수 없음
- 실제 로그인 API는 백엔드 Spring Boot의 `/api/auth/login`에 위치
- 모든 API 요청이 `/ai` 경로로만 설정되어 있어 인증 관련 API가 AI 서비스로 잘못 전달됨
- 백엔드와 AI 서비스의 역할 분리 필요

---

## �� 스크린샷 (선택)
<!-- UI 변경 시 스크린샷 첨부 -->

---

## ✅ 체크리스트
- [x] 코드 동작 확인
- [ ] 관련 테스트 작성/수정
- [ ] 문서 업데이트
- [ ] 리뷰 반영