### PR TITLE
fix: 템플릿 수정 에러 해결 및 기능 개선

### DIFF
--- a/ai/routers/ai_routes.py
+++ b/ai/routers/ai_routes.py
@@ -300,7 +300,7 @@ async def modify_template(request: TemplateModificationRequest):
         if request.chat_history:
             chat_context = "\n".join([
                 f"{msg.get('type', 'user')}: {msg.get('content', '')}" 
-                for msg in request.chat_history[-5:]  # 최근 5개 메시지만 사용
+                for msg in request.chat_history[-6:]  # 최근 6개 메시지만 사용
             ])
         
         # 프롬프트 빌더 사용

--- a/ai/routers/ai_routes.py
+++ b/ai/routers/ai_routes.py
@@ -86,6 +86,7 @@ class TemplateModificationRequest(BaseModel):
     current_template_title: str
     userMessage: str
     chat_history: List[Dict[str, Any]] = []
+    variableList: List[str] = []
 
 class TemplateModificationResponse(BaseModel):
     modified_template: str

--- a/ai/routers/ai_routes.py
+++ b/ai/routers/ai_routes.py
@@ -305,7 +305,7 @@ async def modify_template(request: TemplateModificationRequest):
         # 프롬프트 빌더 사용
         prompt_builder = TemplateModificationPromptBuilder(
             current_template=request.current_template,
-            userMessage=request.userMessage,
+            user_message=request.userMessage,
             chat_context=chat_context
         )
         prompt = prompt_builder.build()

--- a/back/src/main/java/com/example/dto/TemplateRequestDto.java
+++ b/back/src/main/java/com/example/dto/TemplateRequestDto.java
@@ -13,5 +13,7 @@ public class TemplateRequestDto {
     
     private String templateContent;
     private String templateTitle;
+    private String category;
     private List<Object> chatHistory;
+    private List<String> variableList;
 }

--- a/front/src/api/index.ts
+++ b/front/src/api/index.ts
@@ -138,16 +138,13 @@ export const templateApi = {
   
   // 템플릿 검증 (백엔드 API를 통해)
   validateTemplate: (templateContent: string, variableList: Record<string, any>, category?: string, userMessage?: string, templateTitle?: string) => {
-    // 변수 정보를 VariableDto 배열로 변환
-    const variables = Object.entries(variableList).map(([key, value]) => ({
-      variableKey: key,
-      variableValue: String(value)
-    }))
+    // 변수명만 배열로 변환 (백엔드에서 List<String>을 기대함)
+    const variableNames = Object.keys(variableList)
     
     // 백엔드 ValidationRequest 형식에 맞게 데이터 변환
     const validationRequest = {
       templateContent: templateContent,
-      variableList: variables,
+      variableList: variableNames,
       category: category,
       userMessage: userMessage,
       templateTitle: templateTitle
@@ -159,18 +156,13 @@ export const templateApi = {
   },
   
   // 템플릿 수정 요청 (채팅을 통한)
-  modifyTemplate: (templateContent: string, templateTitle: string, userMessage: string, variableList: Record<string, any>, category: string, chatHistory: any[]) => {
-    const variableListArray = Object.entries(variableList).map(([key, value]) => ({
-      variableKey: key,
-      variableValue: String(value)
-    }))
-    
+  modifyTemplate: (templateContent: string, templateTitle: string, userMessage: string, variableList: string[], category: string, chatHistory: any[]) => {
     const modificationRequest = {
       templateContent: templateContent, 
-      category: category,  
-      userMessage: userMessage,
       templateTitle: templateTitle,
-      variableList: variableListArray,
+      userMessage: userMessage,
+      variableList: variableList,
+      category: category,
       chatHistory: chatHistory 
     }
     

--- a/front/src/components/TemplateCreateComponent.vue
+++ b/front/src/components/TemplateCreateComponent.vue
@@ -82,6 +82,12 @@ const handleSubmit = async () => {
       category: responseData.category,
       userMessage: templateStore.userMessage
     }));
+    
+    // 새 템플릿 생성 시 수정 횟수 초기화 (3번으로 설정)
+    const templateId = 'new' // 새 템플릿이므로 'new'로 설정
+    const sessionKey = `template_modifications_${templateId}`
+    sessionStorage.setItem(sessionKey, '3') // 3번 수정 가능
+    
     router.push({
       name: 'template-result',
       state: response.data

--- a/front/src/components/TemplateCreateComponent.vue
+++ b/front/src/components/TemplateCreateComponent.vue
@@ -84,9 +84,7 @@ const handleSubmit = async () => {
     }));
     
     // 새 템플릿 생성 시 수정 횟수 초기화 (3번으로 설정)
-    const templateId = 'new' // 새 템플릿이므로 'new'로 설정
-    const sessionKey = `template_modifications_${templateId}`
-    sessionStorage.setItem(sessionKey, '3') // 3번 수정 가능
+    sessionStorage.setItem('template_modifications_new', '3')
     
     router.push({
       name: 'template-result',

--- a/front/src/views/TemplateResultView.vue
+++ b/front/src/views/TemplateResultView.vue
@@ -166,39 +166,69 @@ const isGenerating = ref(false)
 
 // 정정 횟수 관리 - 세션 기반
 const maxCorrections = 3
-const remainingCorrections = ref(maxCorrections)
+const remainingCorrections = ref(maxCorrections) // 초기값을 maxCorrections로 설정, onMounted에서 세션 값으로 업데이트됨
 
 // 세션 키 생성 함수
 const getSessionKey = () => {
-  const templateId = generatedTemplate.value?.id || 'new'
-  return `template_modifications_${templateId}`
+  // 항상 'template_modifications_new'를 사용하여 일관성 보장
+  return 'template_modifications_new'
 }
 
 // 세션에서 남은 수정 횟수 가져오기
 const getRemainingModifications = () => {
-  const key = getSessionKey()
-  const storedValue = sessionStorage.getItem(key)
-  if (storedValue === null) {
-    // 세션에 값이 없으면 기본값 3 반환
+  try {
+    const key = getSessionKey()
+    const storedValue = sessionStorage.getItem(key)
+    console.log(`세션에서 ${key} 키로 가져온 값:`, storedValue)
+    
+    if (storedValue === null || storedValue === undefined) {
+      // 세션에 값이 없으면 기본값 3으로 설정하고 반환
+      console.log('세션에 값이 없어서 기본값 3으로 설정')
+      sessionStorage.setItem(key, maxCorrections.toString())
+      return maxCorrections
+    }
+    
+    const count = parseInt(storedValue, 10)
+    if (isNaN(count) || count < 0) {
+      console.log('유효하지 않은 값이므로 기본값 3으로 설정')
+      sessionStorage.setItem(key, maxCorrections.toString())
+      return maxCorrections
+    }
+    
+    console.log(`세션에서 가져온 정정 횟수: ${count}`)
+    return count
+  } catch (error) {
+    console.error('세션에서 정정 횟수를 가져오는 중 오류:', error)
+    // 오류 발생 시 기본값 반환
+    const key = getSessionKey()
+    sessionStorage.setItem(key, maxCorrections.toString())
     return maxCorrections
   }
-  const count = parseInt(storedValue)
-  return isNaN(count) ? maxCorrections : count
 }
 
 // 수정 횟수 감소
 const decrementModificationCount = () => {
-  const key = getSessionKey()
-  const currentCount = getRemainingModifications()
-  const newCount = Math.max(0, currentCount - 1)
-  sessionStorage.setItem(key, newCount.toString())
-  return newCount
+  try {
+    const key = getSessionKey()
+    const currentCount = remainingCorrections.value
+    const newCount = Math.max(0, currentCount - 1)
+    sessionStorage.setItem(key, newCount.toString())
+    return newCount
+  } catch (error) {
+    console.error('정정 횟수 감소 중 오류:', error)
+    return 0
+  }
 }
 
 // 수정 횟수 초기화 (새 템플릿 생성 시)
 const resetModificationCount = () => {
-  const key = getSessionKey()
-  sessionStorage.setItem(key, maxCorrections.toString())
+  try {
+    const key = getSessionKey()
+    sessionStorage.setItem(key, maxCorrections.toString())
+    console.log(`정정 횟수 초기화: ${maxCorrections}`)
+  } catch (error) {
+    console.error('정정 횟수 초기화 중 오류:', error)
+  }
 }
 
 // 수정 횟수 리셋 테스트 함수들 (개발자 도구에서 사용) resetModifications() -> 3으로 리셋
@@ -235,6 +265,10 @@ const editedVariables = ref<Record<string, string>>({})
 
 // 컴포넌트 마운트 시 생성된 템플릿 데이터 로드
 onMounted(() => {
+  // 먼저 수정 횟수를 세션에서 가져와서 설정
+  const sessionCorrections = getRemainingModifications()
+  remainingCorrections.value = sessionCorrections
+  
   const savedTemplate = sessionStorage.getItem('generatedTemplate')
   if (savedTemplate) {
     try {
@@ -279,6 +313,7 @@ onMounted(() => {
       ]
       
       console.log('생성된 템플릿 로드됨:', generatedTemplate.value)
+      console.log('최종 정정 횟수:', remainingCorrections.value)
     } catch (error) {
       console.error('템플릿 데이터 파싱 실패:', error)
       router.push('/')
@@ -390,10 +425,10 @@ const closeRejectionSidebar = () => {
 const updateVariables = (newVariables: any) => {
   editedVariables.value = { ...newVariables }
   
-  // 강제로 리렌더링을 위해 nextTick 사용
-  nextTick(() => {
-    console.log('변수 업데이트 완료:', newVariables)
-  })
+    // 강제로 리렌더링을 위해 nextTick 사용
+    nextTick(() => {
+      // 변수 업데이트 완료
+    })
 }
 
 // 변수 토글 상태 변경 감지
@@ -413,12 +448,6 @@ watch(chatHistory, () => {
   scrollToBottom()
 }, { deep: true })
 
-// 수정된 버전 표시
-const showModifiedVersion = () => {
-  // 여기에 수정된 버전을 보여주는 로직을 구현할 수 있습니다
-  console.log('수정된 버전 표시')
-  // 예: 모달 열기, 다른 템플릿 표시 등
-}
 
 // 템플릿 제출
 const submitTemplate = async () => {
@@ -500,8 +529,7 @@ const sendMessage = async () => {
   if (!chatInput.value.trim() || isGenerating.value) return
   
   // 수정 횟수 확인
-  const currentRemainingCount = getRemainingModifications()
-  if (currentRemainingCount <= 0) {
+  if (remainingCorrections.value <= 0) {
     alert('수정 횟수를 모두 사용했습니다. 더 이상 수정할 수 없습니다.')
     return
   }
@@ -556,13 +584,9 @@ const sendMessage = async () => {
     scrollToBottom()
     
     // 템플릿 업데이트
-    console.log('템플릿 수정 전:', templateContent.value)
     const newTemplateContent = response.data.modified_template || response.data.template_text || templateContent.value
     const templateChanged = newTemplateContent !== templateContent.value
     templateContent.value = newTemplateContent
-    console.log('템플릿 수정 후:', templateContent.value)
-    console.log('템플릿 수정 후 길이:', templateContent.value ? templateContent.value.length : 0)
-    console.log('템플릿이 변경되었는가:', templateChanged)
     // 변수 처리 - 백엔드에서 variables 필드 사용
     if (response.data.variables && Array.isArray(response.data.variables)) {
       templateVariables.value = response.data.variables.map((variable: any) => 
@@ -583,16 +607,9 @@ const sendMessage = async () => {
       })
       templateVariables.value = Array.from(found) // 문자열 배열로 변환
     }
-    console.log('템플릿 변수 업데이트:', templateVariables.value)
-    
     // 제목 업데이트 (응답에 제목이 있다면)
     if (response.data.template_title) {
-      console.log('제목 업데이트 전:', templateTitle.value)
       templateTitle.value = response.data.template_title
-      console.log('제목 업데이트 후:', templateTitle.value)
-      console.log('제목 길이:', templateTitle.value.length)
-    } else {
-      console.log('응답에 제목이 없음:', response.data)
     }
     
     // 변수 목록 업데이트: 응답 변수(없으면 파싱 결과) 기준으로 기본값 세팅
@@ -625,14 +642,12 @@ const sendMessage = async () => {
     // 새 버전을 현재 선택된 버전으로 설정
     currentVersion.value = newVersionNumber
     
-    console.log('템플릿 수정 완료:', response.data)
-    
   } catch (error) {
     console.error('템플릿 수정 실패:', error)
     
     // 오류 발생 시 수정 횟수 복원
     const key = getSessionKey()
-    const currentCount = getRemainingModifications()
+    const currentCount = remainingCorrections.value
     const restoredCount = Math.min(maxCorrections, currentCount + 1)
     sessionStorage.setItem(key, restoredCount.toString())
     remainingCorrections.value = restoredCount
@@ -660,7 +675,6 @@ const selectVersion = (versionNumber: number) => {
   }
   
   currentVersion.value = versionNumber
-  console.log(`버전 ${versionNumber} 선택됨`)
   
   // 해당 버전의 템플릿 내용으로 업데이트
   const versionTemplate = versionTemplates.value[versionNumber]

--- a/front/src/views/TemplateResultView.vue
+++ b/front/src/views/TemplateResultView.vue
@@ -164,9 +164,63 @@ const currentVersion = ref(1)
 const chatHistory = ref<any[]>([])
 const isGenerating = ref(false)
 
-// 정정 횟수 관리
+// 정정 횟수 관리 - 세션 기반
 const maxCorrections = 3
 const remainingCorrections = ref(maxCorrections)
+
+// 세션 키 생성 함수
+const getSessionKey = () => {
+  const templateId = generatedTemplate.value?.id || 'new'
+  return `template_modifications_${templateId}`
+}
+
+// 세션에서 남은 수정 횟수 가져오기
+const getRemainingModifications = () => {
+  const key = getSessionKey()
+  const storedValue = sessionStorage.getItem(key)
+  if (storedValue === null) {
+    // 세션에 값이 없으면 기본값 3 반환
+    return maxCorrections
+  }
+  const count = parseInt(storedValue)
+  return isNaN(count) ? maxCorrections : count
+}
+
+// 수정 횟수 감소
+const decrementModificationCount = () => {
+  const key = getSessionKey()
+  const currentCount = getRemainingModifications()
+  const newCount = Math.max(0, currentCount - 1)
+  sessionStorage.setItem(key, newCount.toString())
+  return newCount
+}
+
+// 수정 횟수 초기화 (새 템플릿 생성 시)
+const resetModificationCount = () => {
+  const key = getSessionKey()
+  sessionStorage.setItem(key, maxCorrections.toString())
+}
+
+// 수정 횟수 리셋 테스트 함수들 (개발자 도구에서 사용) resetModifications() -> 3으로 리셋
+const testResetModifications = () => {
+  const key = getSessionKey()
+  sessionStorage.setItem(key, '3')
+  remainingCorrections.value = 3
+  console.log('✅ 수정 횟수를 3으로 리셋했습니다.')
+}
+
+const testSetModifications = (count: number) => {
+  const key = getSessionKey()
+  sessionStorage.setItem(key, count.toString())
+  remainingCorrections.value = count
+  console.log(`✅ 수정 횟수를 ${count}로 설정했습니다.`)
+}
+
+// 전역으로 노출 (개발자 도구에서 사용 가능)
+if (typeof window !== 'undefined') {
+  ;(window as any).resetModifications = testResetModifications
+  ;(window as any).setModifications = testSetModifications
+}
 
 // 버전 관리
 const versions = ref([
@@ -174,7 +228,7 @@ const versions = ref([
 ])
 
 // 각 버전의 템플릿 내용 저장
-const versionTemplates = ref<Record<number, { content: string, title: string, variables: any[] }>>({})
+const versionTemplates = ref<Record<number, { content: string, title: string, variableList: string[] }>>({})
 
 // 사용자가 수정할 수 있는 변수 값들
 const editedVariables = ref<Record<string, string>>({})
@@ -204,7 +258,7 @@ onMounted(() => {
       versionTemplates.value[1] = {
         content: templateContent.value,
         title: templateTitle.value,
-        variables: templateVariables.value
+        variableList: templateVariables.value
       }
       
       // 채팅 히스토리 초기화 - 템플릿 생성 시 입력한 메시지를 첫 메시지로 설정
@@ -234,17 +288,7 @@ onMounted(() => {
     router.push('/')
   }
 })
-
-
-
-// 추천 데이터
-const recommendations = ref([
-  {
-    placeholder: '이 영역을 어케 처리하지?',
-    status: 'pending'
-  }
-])
-
+ 
 // 변수별 대안 데이터
 const variableAlternatives = {
   '수신자': [
@@ -342,8 +386,6 @@ const closeRejectionSidebar = () => {
   currentValidationError.value = null
 }
 
-// 수정 기능 제거에 따라 관련 함수 삭제
-
 // 변수 업데이트
 const updateVariables = (newVariables: any) => {
   editedVariables.value = { ...newVariables }
@@ -359,7 +401,7 @@ watch(showVariables, (newValue) => {
   if (newValue && templateVariables.value.length > 0) {
     // 변수 토글을 활성화했을 때 변수값 설정
     const initialVariables: Record<string, string> = {}
-    templateVariables.value.forEach((variable: any) => {
+      templateVariables.value.forEach((variable: any) => {
       initialVariables[variable.name] = `${variable.name} 값`
     })
     editedVariables.value = initialVariables
@@ -386,12 +428,9 @@ const submitTemplate = async () => {
     // 제출 전 변수 맵 보정: 비어있으면 현재 템플릿 변수로 기본값 구성
     if (!editedVariables.value || Object.keys(editedVariables.value).length === 0) {
       const fallback: Record<string, string> = {}
-      if (Array.isArray(templateVariables.value) && templateVariables.value.length > 0) {
-        templateVariables.value.forEach((variable: any) => {
-          const name = variable?.name
-          if (name) {
-            fallback[name] = `${name} 값`
-          }
+        if (Array.isArray(templateVariables.value) && templateVariables.value.length > 0) {
+          templateVariables.value.forEach((variableName: string) => {
+          fallback[variableName] = `${variableName} 값`
         })
       } else if (templateContent.value) {
         // 변수 배열이 비어 있으면 템플릿 본문에서 변수 패턴을 파싱해 기본값 구성
@@ -460,6 +499,13 @@ const submitTemplate = async () => {
 const sendMessage = async () => {
   if (!chatInput.value.trim() || isGenerating.value) return
   
+  // 수정 횟수 확인
+  const currentRemainingCount = getRemainingModifications()
+  if (currentRemainingCount <= 0) {
+    alert('수정 횟수를 모두 사용했습니다. 더 이상 수정할 수 없습니다.')
+    return
+  }
+  
   const now = new Date()
   const timeString = `${now.getHours().toString().padStart(2, '0')}:${now.getMinutes().toString().padStart(2, '0')}`
   
@@ -479,15 +525,19 @@ const sendMessage = async () => {
   isGenerating.value = true
   
   try {
-    // 정정 횟수 감소
-    remainingCorrections.value--
+    // 수정 횟수 감소 (성공 시에만)
+    const newRemainingCount = decrementModificationCount()
+    remainingCorrections.value = newRemainingCount
     
     // 백엔드 API를 통해 AI 서버에 템플릿 수정 요청
+    // editedVariables를 string[] 형태로 변환
+    const variableList = Object.keys(editedVariables.value)
+    
     const response = await templateApi.modifyTemplate(
       templateContent.value,
       templateTitle.value,
       currentMessage,
-      editedVariables.value,
+      variableList,
       templateCategory.value,
       chatHistory.value
     )
@@ -515,14 +565,14 @@ const sendMessage = async () => {
     console.log('템플릿이 변경되었는가:', templateChanged)
     // 변수 처리 - 백엔드에서 variables 필드 사용
     if (response.data.variables && Array.isArray(response.data.variables)) {
-      templateVariables.value = response.data.variables.map((variable: any) => ({ 
-        name: variable.name || variable 
-      }))
+      templateVariables.value = response.data.variables.map((variable: any) => 
+        variable.name || variable // 문자열 배열로 변환
+      )
     } else if (response.data.metadata && response.data.metadata.variablesDetected) {
-      templateVariables.value = response.data.metadata.variablesDetected.map((name: string) => ({ name }))
+      templateVariables.value = response.data.metadata.variablesDetected
     } else {
       // 응답 변수 비어 있으면 본문에서 파싱하여 변수 배열 생성
-      const patterns = [/\{\{([^}]+)\}\}/g, /#\{([^}]+)\}/g, /\{([^}]+)\}/g]
+      const patterns = [/\{\{([^}]+)\}\}/g, /#\{([^}]+)\}/g]
       const found = new Set<string>()
       patterns.forEach((re) => {
         let m
@@ -531,7 +581,7 @@ const sendMessage = async () => {
           if (name) found.add(name)
         }
       })
-      templateVariables.value = Array.from(found).map((name) => ({ name }))
+      templateVariables.value = Array.from(found) // 문자열 배열로 변환
     }
     console.log('템플릿 변수 업데이트:', templateVariables.value)
     
@@ -548,13 +598,10 @@ const sendMessage = async () => {
     // 변수 목록 업데이트: 응답 변수(없으면 파싱 결과) 기준으로 기본값 세팅
     const rebuilt: Record<string, string> = {}
     const sourceVars = (Array.isArray(response.data.variables) && response.data.variables.length > 0)
-      ? response.data.variables
+      ? response.data.variables.map((variable: any) => variable.name || variable)
       : templateVariables.value
-    sourceVars.forEach((variable: any) => {
-      const name = variable?.name
-      if (name) {
-        rebuilt[name] = name
-      }
+    sourceVars.forEach((variableName: string) => {
+      rebuilt[variableName] = variableName
     })
     editedVariables.value = rebuilt
     
@@ -572,7 +619,7 @@ const sendMessage = async () => {
     versionTemplates.value[newVersionNumber] = {
       content: templateContent.value,
       title: templateTitle.value,
-      variables: templateVariables.value
+      variableList: templateVariables.value
     }
     
     // 새 버전을 현재 선택된 버전으로 설정
@@ -583,8 +630,12 @@ const sendMessage = async () => {
   } catch (error) {
     console.error('템플릿 수정 실패:', error)
     
-    // 오류 발생 시 정정 횟수 복원
-    remainingCorrections.value++
+    // 오류 발생 시 수정 횟수 복원
+    const key = getSessionKey()
+    const currentCount = getRemainingModifications()
+    const restoredCount = Math.min(maxCorrections, currentCount + 1)
+    sessionStorage.setItem(key, restoredCount.toString())
+    remainingCorrections.value = restoredCount
     
     // 오류 메시지 추가
     const errorMessage = {
@@ -616,11 +667,11 @@ const selectVersion = (versionNumber: number) => {
   if (versionTemplate) {
     templateContent.value = versionTemplate.content
     templateTitle.value = versionTemplate.title
-    templateVariables.value = versionTemplate.variables
+    templateVariables.value = versionTemplate.variableList
     
     // 변수 값 초기화
     const initialVariables: Record<string, string> = {}
-    versionTemplate.variables.forEach((variable: any) => {
+    versionTemplate.variableList.forEach((variable: any) => {
       initialVariables[variable.name] = `${variable.name} 값`
     })
     editedVariables.value = initialVariables

--- a/front/src/views/TemplateResultView.vue
+++ b/front/src/views/TemplateResultView.vue
@@ -220,16 +220,6 @@ const decrementModificationCount = () => {
   }
 }
 
-// 수정 횟수 초기화 (새 템플릿 생성 시)
-const resetModificationCount = () => {
-  try {
-    const key = getSessionKey()
-    sessionStorage.setItem(key, maxCorrections.toString())
-    console.log(`정정 횟수 초기화: ${maxCorrections}`)
-  } catch (error) {
-    console.error('정정 횟수 초기화 중 오류:', error)
-  }
-}
 
 // 수정 횟수 리셋 테스트 함수들 (개발자 도구에서 사용) resetModifications() -> 3으로 리셋
 const testResetModifications = () => {
@@ -313,7 +303,6 @@ onMounted(() => {
       ]
       
       console.log('생성된 템플릿 로드됨:', generatedTemplate.value)
-      console.log('최종 정정 횟수:', remainingCorrections.value)
     } catch (error) {
       console.error('템플릿 데이터 파싱 실패:', error)
       router.push('/')


### PR DESCRIPTION
# 제목: 템플릿 수정 에러 해결 및 기능 개선

---

## ✅ PR 종류
- [ ] feat (새로운 기능 추가)
- [x] fix (버그 수정)
- [ ] refactor (코드 리팩토링)
- [ ] docs (문서 추가 및 수정)
- [ ] style (비즈니스 로직 영향 없는 변경)
- [ ] test (테스트 코드 관련 작업)
- [ ] chore (빌드/설정 등 기타 변경)

---

## 📝 작업 내용
- 템플릿에서 채팅 수정이 안되는 오류 해결
  - ai_routes.py에서 파라미터 이름을 수정
    - userMessage → user_message로 변경

- 변수리스트를 타입 list로 통일
- 수정 횟수 제한

### 개발자 도구 테스트 함수
브라우저 개발자 도구 콘솔에서 다음 함수들을 사용할 수 있음
-> 세션이 막히면 테스트가 불가해 정정 횟수 조절을 위해 넣어놓음
- `resetModifications()`: 정정 횟수를 3으로 리셋
- `setModifications(숫자)`: 정정 횟수를 지정된 숫자로 설정
```javascript
// TemplateResultView.vue
// 수정 횟수 리셋 테스트 함수들 (개발자 도구에서 사용) resetModifications() -> 3으로 리셋
const testResetModifications = () => {
  const key = getSessionKey()
  sessionStorage.setItem(key, '3')
  remainingCorrections.value = 3
  console.log('✅ 수정 횟수를 3으로 리셋했습니다.')
}

const testSetModifications = (count: number) => {
  const key = getSessionKey()
  sessionStorage.setItem(key, count.toString())
  remainingCorrections.value = count
  console.log(`✅ 수정 횟수를 ${count}로 설정했습니다.`)
}

// 전역으로 노출 (개발자 도구에서 사용 가능)
if (typeof window !== 'undefined') {
  ;(window as any).resetModifications = testResetModifications
  ;(window as any).setModifications = testSetModifications
}
```

### 2. 코드 분리 제안
현재 `TemplateResultView.vue`가 1290줄로 매우 크므로 분리가 필요

---

## 🔍 변경 이유
- TemplateModificationPromptBuilder의 생성자는 user_message를 받는데, AI 서버에서는 userMessage로 전달하고 있던 문제
- 카운팅만 되고 있었던 수정 횟수 제한을 세션을 통해 제한
- variables를 일관되게 variableList로 변경

---

## 📸 스크린샷 (선택)
<!-- UI 변경 시 스크린샷 첨부 -->

---

## ✅ 체크리스트
- [x] 코드 동작 확인
- [ ] 관련 테스트 작성/수정
- [ ] 문서 업데이트
- [ ] 리뷰 반영
